### PR TITLE
Feat: Label 컴포넌트 구현

### DIFF
--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,0 +1,17 @@
+interface LabelProps {
+  htmlFor: string;
+  children: string;
+}
+
+const Label = ({ htmlFor, children }: LabelProps) => {
+  return (
+    <label
+      className='mb-2 block text-bold-18 text-neutral-200'
+      htmlFor={htmlFor}
+    >
+      {children}
+    </label>
+  );
+};
+
+export default Label;

--- a/stories/Label.stories.ts
+++ b/stories/Label.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Label from '../src/components/Label';
+
+const meta = {
+  title: 'Text/Label',
+  component: Label,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+
+  argTypes: {
+    htmlFor: {
+      control: 'text',
+      description: 'label의 for',
+    },
+    children: {
+      control: 'text',
+      description: 'label 내용',
+    },
+  },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    htmlFor: 'email',
+    children: 'email',
+  },
+};


### PR DESCRIPTION
## 구현 내용
- Label 컴포넌트 구현



## 설명
### 📌 Props

- htmlFor: label의 for 속성 입니다.
- children: label 내용입니다.

## Storybook

[🔗 Storybook-Label](https://6669e8d86796066d6df5993c-wppoioxyje.chromatic.com/?path=/docs/text-label--docs)

<img width="1050" alt="image" src="https://github.com/designsoo/mingle-ui/assets/77719310/116b91b2-f11a-4b56-9b1e-752d68f4f876">

