### PR TITLE
Feat: ErrorMessage 컴포넌트 구현

### DIFF
--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,0 +1,9 @@
+interface ErrorMessageProps {
+  children: string;
+}
+
+const ErrorMessage = ({ children }: ErrorMessageProps) => {
+  return <p className='text-base-13 text-red-600'>{children}</p>;
+};
+
+export default ErrorMessage;

--- a/stories/ErrorMessage.stories.ts
+++ b/stories/ErrorMessage.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ErrorMessage from '../src/components/ErrorMessage';
+
+const meta = {
+  title: 'Text/ErrorMessage',
+  component: ErrorMessage,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+
+  argTypes: {
+    children: {
+      control: 'text',
+      description: 'ErrorMessage 내용',
+    },
+  },
+} satisfies Meta<typeof ErrorMessage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Email is required.',
+  },
+};


### PR DESCRIPTION
## 구현 내용

- ErrorMessage 컴포넌트 구현

## 설명

### 📌 Props
- children: 에러 메시지 입니다.

## Storybook

[🔗 Storybook-ErrorMessage](https://6669e8d86796066d6df5993c-wppoioxyje.chromatic.com/?path=/docs/text-errormessage--docs)

<img width="1061" alt="image" src="https://github.com/designsoo/mingle-ui/assets/77719310/e5eee8b3-922f-43ce-8d97-2816f592783a">

