### PR TITLE
Feat: InputField 컴포넌트 구현

### DIFF
--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -1,5 +1,5 @@
-import Input from './Input';
-import ErrorMessage from './ErrorMessage';
+import Input from '@/components/Input';
+import ErrorMessage from '@/components/ErrorMessage';
 
 interface InputFieldProps {
   id: string;

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -1,0 +1,29 @@
+import Input from './Input';
+import ErrorMessage from './ErrorMessage';
+
+interface InputFieldProps {
+  id: string;
+  name: string;
+  type: string;
+  placeholder: string;
+  errorMessage: string;
+  isError: boolean;
+}
+
+const InputField = ({
+  id,
+  name,
+  type,
+  placeholder,
+  errorMessage,
+  isError = false,
+}: InputFieldProps) => {
+  return (
+    <div className='input-field relative'>
+      <Input id={id} name={name} type={type} placeholder={placeholder} />
+      {isError && <ErrorMessage>{errorMessage}</ErrorMessage>}
+    </div>
+  );
+};
+
+export default InputField;

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,10 @@
   .base-transition {
     @apply transition-all duration-300 ease-in-out;
   }
+
+  .input-field > p {
+    @apply absolute -bottom-6;
+  }
 }
 
 @layer utilities {

--- a/stories/InputField.stories.ts
+++ b/stories/InputField.stories.ts
@@ -40,13 +40,24 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const EmailField: Story = {
   args: {
     id: 'email',
     name: 'email',
     type: 'email',
     placeholder: 'Email',
-    errorMessage: 'email is required',
+    errorMessage: 'Email is required',
+    isError: true,
+  },
+};
+
+export const PasswordField: Story = {
+  args: {
+    id: 'password',
+    name: 'password',
+    type: 'password',
+    placeholder: 'Password',
+    errorMessage: 'Password is required',
     isError: true,
   },
 };

--- a/stories/InputField.stories.ts
+++ b/stories/InputField.stories.ts
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import InputField from '../src/components/InputField';
+
+const meta = {
+  title: 'InputField/InputField',
+  component: InputField,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+
+  argTypes: {
+    id: {
+      control: 'text',
+      description: 'Input의 id',
+    },
+    name: {
+      control: 'text',
+      description: 'Input의 name',
+    },
+    type: {
+      control: 'text',
+      description: 'Input의 type',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Input의 placeholder',
+    },
+    errorMessage: {
+      control: 'text',
+      description: '에러 메시지',
+    },
+    isError: {
+      control: 'boolean',
+      description: '에러 유무',
+    },
+  },
+} satisfies Meta<typeof InputField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    id: 'email',
+    name: 'email',
+    type: 'email',
+    placeholder: 'Email',
+    errorMessage: 'email is required',
+    isError: true,
+  },
+};


### PR DESCRIPTION
## 구현 내용

- InputField 컴포넌트 구현

## 설명

### 📌 Props
- id
- name
- type
- placeholder
- errorMessage
- isError: true일 경우, ErrorMessage 컴포넌트를 통해 에러 메시지를 표시합니다.

## Storybook

[🔗 Storybook-InputField](https://6669e8d86796066d6df5993c-aavmtlmpwf.chromatic.com/?path=/docs/inputfield-inputfield--docs)

<img width="982" alt="image" src="https://github.com/designsoo/mingle-ui/assets/77719310/f157207d-dfc3-479d-a5b1-34a95e5727ac">

<img width="976" alt="image" src="https://github.com/designsoo/mingle-ui/assets/77719310/a744d3ad-8ec7-49de-b74c-720564e85288">

