### PR TITLE
Refactor: InputField props 추가, input type 조건 추가, 색상 전역 변수 설정, 자동완성 스타일 제거

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -37,7 +37,7 @@ const Input = ({
         className='h-full w-full bg-transparent text-base-16 text-neutral-200 outline-none placeholder:text-neutral-700'
         id={id}
         name={name}
-        type={inputType}
+        type={type === 'password' ? inputType : type}
         placeholder={placeholder}
         {...rest}
       />

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -1,5 +1,6 @@
 import Input from '@/components/Input';
 import ErrorMessage from '@/components/ErrorMessage';
+import { InputHTMLAttributes } from 'react';
 
 interface InputFieldProps {
   id: string;
@@ -17,10 +18,17 @@ const InputField = ({
   placeholder,
   errorMessage,
   isError = false,
-}: InputFieldProps) => {
+  ...rest
+}: InputFieldProps & InputHTMLAttributes<HTMLInputElement>) => {
   return (
     <div className='input-field relative'>
-      <Input id={id} name={name} type={type} placeholder={placeholder} />
+      <Input
+        id={id}
+        name={name}
+        type={type}
+        placeholder={placeholder}
+        {...rest}
+      />
       {isError && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </div>
   );

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -6,7 +6,7 @@ interface LabelProps {
 const Label = ({ htmlFor, children }: LabelProps) => {
   return (
     <label
-      className='mb-2 block text-bold-18 text-neutral-200'
+      className='mb-2 block text-start text-bold-18 text-neutral-200'
       htmlFor={htmlFor}
     >
       {children}

--- a/src/index.css
+++ b/src/index.css
@@ -2,15 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --mg-color-text: #e5e5e5;
+  --mg-color-background: #0a0a0a;
+}
+
 @layer base {
   * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+    @apply m-0 box-border p-0;
   }
 
   body {
     @apply bg-neutral-950 font-jakarta;
+  }
+
+  input:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 30px var(--mg-color-background) inset;
+    -webkit-text-fill-color: var(--mg-color-text);
   }
 }
 


### PR DESCRIPTION
## 구현 내용

- InputField 리팩터링

## 설명

- InputField props 추가: input 속성을 props로 받아 적용되도록 InputField 컴포넌트를 리팩터링하였습니다.
- input type 조건 추가: input의 type이 password인 경우와 아닌 경우를 삼항 연산자를 사용하여 타입별로 다르게 적용되도록 수정하였습니다.
- 자동완성 스타일 제거: input 필드의 자동완성 스타일을 제거하였습니다.
- 색상 전역 변수 설정: 전역에서 사용되는 색상을 :root에서 CSS 변수로 설정하였습니다.