### PR TITLE
Refactor: Primary Button 컴포넌트 리팩터링(중복 코드 제거/props 옵셔널 지정)

### DIFF
--- a/src/components/PrimaryButton.tsx
+++ b/src/components/PrimaryButton.tsx
@@ -4,35 +4,27 @@ type ButtonSize = 'sm' | 'md' | 'lg';
 interface PrimaryButtonProps {
   children: string;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
-  size: ButtonSize;
-  variant: ButtonTheme;
-  disabled: boolean;
+  size?: ButtonSize;
+  variant?: ButtonTheme;
+  disabled?: boolean;
 }
 
-const primary = 'button-fill-primary';
-const secondary = 'button-fill-secondary';
-const stroke = 'button-stroke';
-
 const buttonTheme: Record<ButtonTheme, string> = {
-  primary,
-  secondary,
-  stroke,
+  primary: 'button-fill-primary',
+  secondary: 'button-fill-secondary',
+  stroke: 'button-stroke',
 };
 
-const sm = 'h-9 px-2';
-const md = 'h-11 px-3';
-const lg = 'h-12 w-full text-bold-16';
-
 const buttonSize: Record<ButtonSize, string> = {
-  sm,
-  md,
-  lg,
+  sm: 'h-9 px-2',
+  md: 'h-11 px-3',
+  lg: 'h-12 w-full text-bold-16',
 };
 
 const PrimaryButton = ({
   children,
   onClick,
-  size = 'lg',
+  size = 'md',
   variant = 'primary',
   disabled = false,
 }: PrimaryButtonProps) => {

--- a/stories/PrimaryButton.stories.tsx
+++ b/stories/PrimaryButton.stories.tsx
@@ -19,15 +19,17 @@ const meta = {
 
   argTypes: {
     size: {
-      control: 'radio',
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
       description: 'button의 size(기본형: md)',
     },
     variant: {
       control: 'select',
+      options: ['primary', 'secondary', 'stroke'],
       description: 'button의 variant(기본형: primary)',
     },
     children: {
-      control: 'select',
+      control: 'text',
       description: 'button의 text',
     },
   },


### PR DESCRIPTION
## 구현 내용

- Primary Button 컴포넌트 리팩터링

## 설명

### 코드 중복 제거
- 기존에 각 버튼 테마와 크기를 개별 상수로 정의하고 다시 객체에 할당하는 중복된 코드를 제거했습니다.
- `buttonTheme` 및 `buttonSize` 객체를 직접 정의하였습니다.

### props 옵셔널 지정
- `size`, `variant`, `disabled`를 선택 사항으로 지정하고, 기본값을 설정하여 컴포넌트 사용의 유연성을 고려하여 개선했습니다.